### PR TITLE
a small copy and style update change

### DIFF
--- a/src/app/_components/efforts-list.tsx
+++ b/src/app/_components/efforts-list.tsx
@@ -46,7 +46,7 @@ export function EffortsList() {
                   href="https://github.com/ronanru/uploadthing-darkmode"
                   target="_blank"
                 >
-                  Chrome Extension
+                  Chrome and Firefox Extension
                 </a>
               </CardTitle>
               <CardDescription>
@@ -59,7 +59,7 @@ export function EffortsList() {
                   @ronanru
                 </a>{" "}
                 hunted down a browser solution in which you can add dark mode
-                via a chrome extension.
+                via a Chrome or Firefox extension.
               </CardDescription>
             </CardHeader>
           </Card>

--- a/src/components/ui/theo-card.tsx
+++ b/src/components/ui/theo-card.tsx
@@ -10,7 +10,7 @@ export default function TheoCard() {
   return (
     <HoverCard>
       <HoverCardTrigger asChild>
-        <span className="text-[hsl(280,100%,70%)] underline">THEO</span>
+        <span className="text-[hsl(280,100%,70%)] underline cursor-pointer">THEO</span>
         {/* <a
           href="https://github.com/pingdotgg/uploadthing/issues/9"
           className="text-[hsl(280,100%,70%)] underline"


### PR DESCRIPTION
- reflecting changes that the chrome extension now includes a firefox version
- changing the pink `THEO` text to use `cursor: pointer` instead of `cursor: text`