### PR TITLE
added a racial slurs filter to the trpc Petition router

### DIFF
--- a/src/server/api/routers/petition.ts
+++ b/src/server/api/routers/petition.ts
@@ -6,14 +6,46 @@ import {
   publicProcedure,
 } from "@/server/api/trpc";
 
+import type { Petition } from "@prisma/client";
+
+function doesContainHateSpeech(input: string) {
+  input = input.toLowerCase();
+  let result = false;
+  // Sorry for putting this in the codebase,
+  // but I need to give a string to filter against
+  const slurs = [
+    "nigger",
+    "n i g g e r",
+    "niger",
+    "nigga",
+    "niga",
+    " nig ", // the spaces on either side are to make sure this is on it's own
+    "beaner",
+    "chink",
+  ];
+
+  slurs.forEach((value: string) => {
+    if (input.includes(value)) result = true;
+  });
+  return result;
+}
+
 export const petitionRouter = createTRPCRouter({
-  getList: publicProcedure.query(({ ctx }) => {
-    return ctx.db.petition.findMany({});
+  getList: publicProcedure.query(async ({ ctx }) => {
+    const result = new Array<Petition>();
+    const fetched = await ctx.db.petition.findMany({});
+    fetched.forEach((value) => {
+      if (!doesContainHateSpeech(value.name ?? "")) {
+        result.push(value);
+      }
+    });
+    return result;
   }),
 
   addEntry: publicProcedure
     .input(z.object({ name: z.string().min(1) }))
     .mutation(async ({ ctx, input }) => {
+      if (doesContainHateSpeech(input.name)) return;
       return ctx.db.petition.create({
         // orderBy: { : "desc" },
         data: {


### PR DESCRIPTION
# Basic hate speech filter

some users were leaving racial slurs in the petition. I made a quick filtering mechanism to reject any petition containing racial slurs.

Fixes #6

### Trigger warning the code contains racial slurs
I had to give the filter something to check against so it was kinda unavoidable.

![Screenshot from 2024-02-10 08-44-24](https://github.com/ahmad1702/upload-thing-dark-mode-free/assets/93905215/61f18378-2a2a-4f2c-8482-3b56bf6bc086)

